### PR TITLE
Make error message OS agnostic: use String.format() and "%n" instead …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,8 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>1.3.0</version>
+      <!-- sadly [2.0.0, 3.0.0) does not work -->
+      <version>[2.1.0, 2.99.0]</version>
     </dependency>
     <dependency>
       <groupId>joda-time</groupId>

--- a/src/main/java/org/assertj/jodatime/error/ShouldBeAfter.java
+++ b/src/main/java/org/assertj/jodatime/error/ShouldBeAfter.java
@@ -48,6 +48,6 @@ public class ShouldBeAfter extends BasicErrorMessageFactory {
   }
 
   private ShouldBeAfter(Object actual, Object other, ComparisonStrategy comparisonStrategy) {
-    super("\nExpecting:\n  <%s>\nto be strictly after:\n  <%s>\n%s", actual, other, comparisonStrategy);
+    super("%nExpecting:%n  <%s>%nto be strictly after:%n  <%s>%n%s", actual, other, comparisonStrategy);
   }
 }

--- a/src/main/java/org/assertj/jodatime/error/ShouldBeAfterOrEqualsTo.java
+++ b/src/main/java/org/assertj/jodatime/error/ShouldBeAfterOrEqualsTo.java
@@ -49,6 +49,6 @@ public class ShouldBeAfterOrEqualsTo extends BasicErrorMessageFactory {
   }
 
   private ShouldBeAfterOrEqualsTo(Object actual, Object other, ComparisonStrategy comparisonStrategy) {
-    super("\nExpecting:\n  <%s>\nto be after or equals to:\n  <%s>\n%s", actual, other, comparisonStrategy);
+    super("%nExpecting:%n  <%s>%nto be after or equals to:%n  <%s>%n%s", actual, other, comparisonStrategy);
  }
 }

--- a/src/main/java/org/assertj/jodatime/error/ShouldBeBefore.java
+++ b/src/main/java/org/assertj/jodatime/error/ShouldBeBefore.java
@@ -48,6 +48,6 @@ public class ShouldBeBefore extends BasicErrorMessageFactory {
   }
 
   private ShouldBeBefore(Object actual, Object other, ComparisonStrategy comparisonStrategy) {
-    super("\nExpecting:\n  <%s>\nto be strictly before:\n  <%s>\n%s", actual, other, comparisonStrategy);
+    super("%nExpecting:%n  <%s>%nto be strictly before:%n  <%s>%n%s", actual, other, comparisonStrategy);
   }
 }

--- a/src/main/java/org/assertj/jodatime/error/ShouldBeBeforeOrEqualsTo.java
+++ b/src/main/java/org/assertj/jodatime/error/ShouldBeBeforeOrEqualsTo.java
@@ -49,6 +49,6 @@ public class ShouldBeBeforeOrEqualsTo extends BasicErrorMessageFactory {
   }
 
   private ShouldBeBeforeOrEqualsTo(Object actual, Object other, ComparisonStrategy comparisonStrategy) {
-    super("\nExpecting:\n  <%s>\nto be before or equals to:\n  <%s>\n%s", actual, other, comparisonStrategy);
+    super("%nExpecting:%n  <%s>%nto be before or equals to:%n  <%s>%n%s", actual, other, comparisonStrategy);
   }
 }

--- a/src/main/java/org/assertj/jodatime/error/ShouldBeEqualIgnoringHours.java
+++ b/src/main/java/org/assertj/jodatime/error/ShouldBeEqualIgnoringHours.java
@@ -36,6 +36,6 @@ public class ShouldBeEqualIgnoringHours extends BasicErrorMessageFactory {
   }
 
   private ShouldBeEqualIgnoringHours(Object actual, Object other) {
-    super("\nExpecting:\n  <%s>\nto have same year, month and day as:\n  <%s>\nbut had not.", actual, other);
+    super("%nExpecting:%n  <%s>%nto have same year, month and day as:%n  <%s>%nbut had not.", actual, other);
   }
 }

--- a/src/main/java/org/assertj/jodatime/error/ShouldBeEqualIgnoringMillis.java
+++ b/src/main/java/org/assertj/jodatime/error/ShouldBeEqualIgnoringMillis.java
@@ -36,7 +36,7 @@ public class ShouldBeEqualIgnoringMillis extends BasicErrorMessageFactory {
   }
 
   private ShouldBeEqualIgnoringMillis(Object actual, Object other) {
-    super("\nExpecting:\n  <%s>\nto have same year, month, day, hour, minute and second as:\n  <%s>\nbut had not.",
+    super("%nExpecting:%n  <%s>%nto have same year, month, day, hour, minute and second as:%n  <%s>%nbut had not.",
         actual, other);
   }
 }

--- a/src/main/java/org/assertj/jodatime/error/ShouldBeEqualIgnoringMinutes.java
+++ b/src/main/java/org/assertj/jodatime/error/ShouldBeEqualIgnoringMinutes.java
@@ -36,6 +36,6 @@ public class ShouldBeEqualIgnoringMinutes extends BasicErrorMessageFactory {
   }
 
   private ShouldBeEqualIgnoringMinutes(Object actual, Object other) {
-    super("\nExpecting:\n  <%s>\nto have same year, month, day and hour as:\n  <%s>\nbut had not.", actual, other);
+    super("%nExpecting:%n  <%s>%nto have same year, month, day and hour as:%n  <%s>%nbut had not.", actual, other);
   }
 }

--- a/src/main/java/org/assertj/jodatime/error/ShouldBeEqualIgnoringSeconds.java
+++ b/src/main/java/org/assertj/jodatime/error/ShouldBeEqualIgnoringSeconds.java
@@ -36,7 +36,7 @@ public class ShouldBeEqualIgnoringSeconds extends BasicErrorMessageFactory {
   }
 
   private ShouldBeEqualIgnoringSeconds(Object actual, Object other) {
-    super("\nExpecting:\n  <%s>\nto have same year, month, day, hour and minute as:\n  <%s>\nbut had not.", actual,
+    super("%nExpecting:%n  <%s>%nto have same year, month, day, hour and minute as:%n  <%s>%nbut had not.", actual,
         other);
   }
 }

--- a/src/test/java/org/assertj/jodatime/api/JodaTimeBaseTest.java
+++ b/src/test/java/org/assertj/jodatime/api/JodaTimeBaseTest.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.jodatime.api;
 
+import static java.lang.String.format;
 import static org.junit.rules.ExpectedException.none;
 
 import org.junit.Assert;
@@ -25,11 +26,11 @@ public class JodaTimeBaseTest {
 
   protected void expectException(Class<? extends Throwable> type, String message) {
     thrown.expect(type);
-    thrown.expectMessage(message);
+    thrown.expectMessage(format(message));
   }
   
   protected void expectIllegalArgumentException(String message) {
-    expectException(IllegalArgumentException.class, message);
+    expectException(IllegalArgumentException.class, format(message));
   }
 
   public void failBecauseExpectedAssertionErrorWasNotThrown() {

--- a/src/test/java/org/assertj/jodatime/api/datetime/DateTimeAssert_isAfterOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/jodatime/api/datetime/DateTimeAssert_isAfterOrEqualTo_Test.java
@@ -12,11 +12,11 @@
  */
 package org.assertj.jodatime.api.datetime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.jodatime.api.Assertions.assertThat;
-
 import static org.joda.time.DateTimeZone.UTC;
 
 import org.joda.time.DateTime;
@@ -63,7 +63,7 @@ public class DateTimeAssert_isAfterOrEqualTo_Test extends DateTimeAssertBaseTest
     try {
       assertThat(new DateTime(2000, 1, 5, 3, 0, 5, UTC)).isAfterOrEqualTo(new DateTime(2012, 1, 1, 3, 3, 3, UTC));
     } catch (AssertionError e) {
-      assertThat(e).hasMessage("\nExpecting:\n  <2000-01-05T03:00:05.000Z>\nto be after or equals to:\n  <2012-01-01T03:03:03.000Z>\n");
+      assertThat(e).hasMessage(format("%nExpecting:%n  <2000-01-05T03:00:05.000Z>%nto be after or equals to:%n  <2012-01-01T03:03:03.000Z>%n"));
       return;
     }
     fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/jodatime/api/datetime/DateTimeAssert_isAfter_Test.java
+++ b/src/test/java/org/assertj/jodatime/api/datetime/DateTimeAssert_isAfter_Test.java
@@ -12,11 +12,11 @@
  */
 package org.assertj.jodatime.api.datetime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.jodatime.api.Assertions.assertThat;
-
 import static org.joda.time.DateTimeZone.UTC;
 
 import org.joda.time.DateTime;
@@ -66,7 +66,7 @@ public class DateTimeAssert_isAfter_Test extends DateTimeAssertBaseTest {
     try {
       assertThat(new DateTime(2000, 1, 5, 3, 0, 5, UTC)).isAfter(new DateTime(2012, 1, 1, 3, 3, 3, UTC));
     } catch (AssertionError e) {
-      assertThat(e).hasMessage("\nExpecting:\n  <2000-01-05T03:00:05.000Z>\nto be strictly after:\n  <2012-01-01T03:03:03.000Z>\n");
+      assertThat(e).hasMessage(format("%nExpecting:%n  <2000-01-05T03:00:05.000Z>%nto be strictly after:%n  <2012-01-01T03:03:03.000Z>%n"));
       return;
     }
     fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/jodatime/api/datetime/DateTimeAssert_isBeforeOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/jodatime/api/datetime/DateTimeAssert_isBeforeOrEqualTo_Test.java
@@ -12,11 +12,11 @@
  */
 package org.assertj.jodatime.api.datetime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.jodatime.api.Assertions.assertThat;
-
 import static org.joda.time.DateTimeZone.UTC;
 
 import org.joda.time.DateTime;
@@ -63,7 +63,7 @@ public class DateTimeAssert_isBeforeOrEqualTo_Test extends DateTimeAssertBaseTes
     try {
       assertThat(new DateTime(2000, 1, 5, 3, 0, 5, UTC)).isBeforeOrEqualTo(new DateTime(1998, 1, 1, 3, 3, 3, UTC));
     } catch (AssertionError e) {
-      assertThat(e).hasMessage("\nExpecting:\n  <2000-01-05T03:00:05.000Z>\nto be before or equals to:\n  <1998-01-01T03:03:03.000Z>\n");
+      assertThat(e).hasMessage(format("%nExpecting:%n  <2000-01-05T03:00:05.000Z>%nto be before or equals to:%n  <1998-01-01T03:03:03.000Z>%n"));
       return;
     }
     fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/jodatime/api/datetime/DateTimeAssert_isBefore_Test.java
+++ b/src/test/java/org/assertj/jodatime/api/datetime/DateTimeAssert_isBefore_Test.java
@@ -12,11 +12,11 @@
  */
 package org.assertj.jodatime.api.datetime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.jodatime.api.Assertions.assertThat;
-
 import static org.joda.time.DateTimeZone.UTC;
 
 import org.joda.time.DateTime;
@@ -67,7 +67,7 @@ public class DateTimeAssert_isBefore_Test extends DateTimeAssertBaseTest {
     try {
       assertThat(new DateTime(2000, 1, 5, 3, 0, UTC)).isBefore(new DateTime(1998, 1, 1, 3, 3, UTC));
     } catch (AssertionError e) {
-      assertThat(e).hasMessage("\nExpecting:\n  <2000-01-05T03:00:00.000Z>\nto be strictly before:\n  <1998-01-01T03:03:00.000Z>\n");
+      assertThat(e).hasMessage(format("%nExpecting:%n  <2000-01-05T03:00:00.000Z>%nto be strictly before:%n  <1998-01-01T03:03:00.000Z>%n"));
       return;
     }
     fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/jodatime/api/datetime/DateTimeAssert_isEqualToIgnoringHours_Test.java
+++ b/src/test/java/org/assertj/jodatime/api/datetime/DateTimeAssert_isEqualToIgnoringHours_Test.java
@@ -12,16 +12,15 @@
  */
 package org.assertj.jodatime.api.datetime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.jodatime.api.DateTimeAssert.NULL_DATE_TIME_PARAMETER_MESSAGE;
 import static org.assertj.jodatime.api.Assertions.assertThat;
-
 import static org.joda.time.DateTimeZone.UTC;
 
 import org.assertj.jodatime.api.JodaTimeBaseTest;
-
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Test;
@@ -59,8 +58,8 @@ public class DateTimeAssert_isEqualToIgnoringHours_Test extends JodaTimeBaseTest
       assertThat(refDatetime).isEqualToIgnoringHours(refDatetime.minusHours(1));
     } catch (AssertionError e) {
       assertThat(e.getMessage())
-          .isEqualTo(
-              "\nExpecting:\n  <2000-01-02T00:00:00.000Z>\nto have same year, month and day as:\n  <2000-01-01T23:00:00.000Z>\nbut had not.");
+          .isEqualTo(format(
+              "%nExpecting:%n  <2000-01-02T00:00:00.000Z>%nto have same year, month and day as:%n  <2000-01-01T23:00:00.000Z>%nbut had not."));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();
@@ -72,8 +71,8 @@ public class DateTimeAssert_isEqualToIgnoringHours_Test extends JodaTimeBaseTest
       assertThat(refDatetime).isEqualToIgnoringHours(refDatetime.minusMillis(1));
     } catch (AssertionError e) {
       assertThat(e.getMessage())
-          .isEqualTo(
-              "\nExpecting:\n  <2000-01-02T00:00:00.000Z>\nto have same year, month and day as:\n  <2000-01-01T23:59:59.999Z>\nbut had not.");
+          .isEqualTo(format(
+              "%nExpecting:%n  <2000-01-02T00:00:00.000Z>%nto have same year, month and day as:%n  <2000-01-01T23:59:59.999Z>%nbut had not."));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();

--- a/src/test/java/org/assertj/jodatime/api/datetime/DateTimeAssert_isEqualToIgnoringMilliseconds_Test.java
+++ b/src/test/java/org/assertj/jodatime/api/datetime/DateTimeAssert_isEqualToIgnoringMilliseconds_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.jodatime.api.datetime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.jodatime.api.DateTimeAssert.NULL_DATE_TIME_PARAMETER_MESSAGE;
@@ -39,8 +40,8 @@ public class DateTimeAssert_isEqualToIgnoringMilliseconds_Test extends JodaTimeB
       assertThat(refDatetime).isEqualToIgnoringMillis(refDatetime.plusSeconds(1));
     } catch (AssertionError e) {
       assertThat(e.getMessage())
-          .isEqualTo(
-              "\nExpecting:\n  <2000-01-01T00:00:01.000Z>\nto have same year, month, day, hour, minute and second as:\n  <2000-01-01T00:00:02.000Z>\nbut had not.");
+          .isEqualTo(format(
+              "%nExpecting:%n  <2000-01-01T00:00:01.000Z>%nto have same year, month, day, hour, minute and second as:%n  <2000-01-01T00:00:02.000Z>%nbut had not."));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();
@@ -52,8 +53,8 @@ public class DateTimeAssert_isEqualToIgnoringMilliseconds_Test extends JodaTimeB
       assertThat(refDatetime).isEqualToIgnoringMillis(refDatetime.minusMillis(1));
     } catch (AssertionError e) {
       assertThat(e.getMessage())
-          .isEqualTo(
-              "\nExpecting:\n  <2000-01-01T00:00:01.000Z>\nto have same year, month, day, hour, minute and second as:\n  <2000-01-01T00:00:00.999Z>\nbut had not.");
+          .isEqualTo(format(
+              "%nExpecting:%n  <2000-01-01T00:00:01.000Z>%nto have same year, month, day, hour, minute and second as:%n  <2000-01-01T00:00:00.999Z>%nbut had not."));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();

--- a/src/test/java/org/assertj/jodatime/api/datetime/DateTimeAssert_isEqualToIgnoringMinutes_Test.java
+++ b/src/test/java/org/assertj/jodatime/api/datetime/DateTimeAssert_isEqualToIgnoringMinutes_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.jodatime.api.datetime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.jodatime.api.DateTimeAssert.NULL_DATE_TIME_PARAMETER_MESSAGE;
@@ -38,8 +39,8 @@ public class DateTimeAssert_isEqualToIgnoringMinutes_Test extends JodaTimeBaseTe
       assertThat(refDatetime).isEqualToIgnoringMinutes(refDatetime.minusMinutes(1));
     } catch (AssertionError e) {
       assertThat(e.getMessage())
-          .isEqualTo(
-              "\nExpecting:\n  <2000-01-01T23:00:00.000Z>\nto have same year, month, day and hour as:\n  <2000-01-01T22:59:00.000Z>\nbut had not.");
+          .isEqualTo(format(
+              "%nExpecting:%n  <2000-01-01T23:00:00.000Z>%nto have same year, month, day and hour as:%n  <2000-01-01T22:59:00.000Z>%nbut had not."));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();
@@ -51,8 +52,8 @@ public class DateTimeAssert_isEqualToIgnoringMinutes_Test extends JodaTimeBaseTe
       assertThat(refDatetime).isEqualToIgnoringMinutes(refDatetime.minusMillis(1));
     } catch (AssertionError e) {
       assertThat(e.getMessage())
-          .isEqualTo(
-              "\nExpecting:\n  <2000-01-01T23:00:00.000Z>\nto have same year, month, day and hour as:\n  <2000-01-01T22:59:59.999Z>\nbut had not.");
+          .isEqualTo(format(
+              "%nExpecting:%n  <2000-01-01T23:00:00.000Z>%nto have same year, month, day and hour as:%n  <2000-01-01T22:59:59.999Z>%nbut had not."));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();

--- a/src/test/java/org/assertj/jodatime/api/datetime/DateTimeAssert_isEqualToIgnoringSeconds_Test.java
+++ b/src/test/java/org/assertj/jodatime/api/datetime/DateTimeAssert_isEqualToIgnoringSeconds_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.jodatime.api.datetime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.jodatime.api.DateTimeAssert.NULL_DATE_TIME_PARAMETER_MESSAGE;
@@ -38,8 +39,8 @@ public class DateTimeAssert_isEqualToIgnoringSeconds_Test extends JodaTimeBaseTe
       assertThat(refDatetime).isEqualToIgnoringSeconds(refDatetime.plusMinutes(1));
     } catch (AssertionError e) {
       assertThat(e.getMessage())
-          .isEqualTo(
-              "\nExpecting:\n  <2000-01-01T23:51:00.000Z>\nto have same year, month, day, hour and minute as:\n  <2000-01-01T23:52:00.000Z>\nbut had not.");
+          .isEqualTo(format(
+              "%nExpecting:%n  <2000-01-01T23:51:00.000Z>%nto have same year, month, day, hour and minute as:%n  <2000-01-01T23:52:00.000Z>%nbut had not."));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();
@@ -51,8 +52,8 @@ public class DateTimeAssert_isEqualToIgnoringSeconds_Test extends JodaTimeBaseTe
       assertThat(refDatetime).isEqualToIgnoringSeconds(refDatetime.minusMillis(1));
     } catch (AssertionError e) {
       assertThat(e.getMessage())
-          .isEqualTo(
-              "\nExpecting:\n  <2000-01-01T23:51:00.000Z>\nto have same year, month, day, hour and minute as:\n  <2000-01-01T23:50:59.999Z>\nbut had not.");
+          .isEqualTo(format(
+              "%nExpecting:%n  <2000-01-01T23:51:00.000Z>%nto have same year, month, day, hour and minute as:%n  <2000-01-01T23:50:59.999Z>%nbut had not."));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();

--- a/src/test/java/org/assertj/jodatime/api/datetime/DateTimeAssert_isIn_errors_Test.java
+++ b/src/test/java/org/assertj/jodatime/api/datetime/DateTimeAssert_isIn_errors_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.jodatime.api.datetime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.jodatime.api.Assertions.assertThat;
@@ -44,8 +45,8 @@ public class DateTimeAssert_isIn_errors_Test extends DateTimeAssertBaseTest {
     try {
       assertThat(new DateTime(2000, 1, 5, 3, 0, 5, UTC)).isIn(new DateTime(2012, 1, 1, 3, 3, 3, UTC).toString());
     } catch (AssertionError e) {
-      assertThat(e).hasMessage(
-          "\nExpecting:\n <2000-01-05T03:00:05.000Z>\nto be in:\n <[2012-01-01T03:03:03.000Z]>\n");
+      assertThat(e).hasMessage(format(
+          "%nExpecting:%n <2000-01-05T03:00:05.000Z>%nto be in:%n <[2012-01-01T03:03:03.000Z]>%n"));
       return;
     }
     fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/jodatime/api/datetime/DateTimeAssert_isNotEqualTo_errors_Test.java
+++ b/src/test/java/org/assertj/jodatime/api/datetime/DateTimeAssert_isNotEqualTo_errors_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.jodatime.api.datetime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.jodatime.api.Assertions.assertThat;
@@ -45,7 +46,7 @@ public class DateTimeAssert_isNotEqualTo_errors_Test extends DateTimeAssertBaseT
       DateTime date = new DateTime(2000, 1, 5, 3, 0, 5, UTC);
       assertThat(date).isNotEqualTo(date.toString());
     } catch (AssertionError e) {
-      assertThat(e).hasMessage("\nExpecting:\n <2000-01-05T03:00:05.000Z>\nnot to be equal to:\n <2000-01-05T03:00:05.000Z>\n");
+      assertThat(e).hasMessage(format("%nExpecting:%n <2000-01-05T03:00:05.000Z>%nnot to be equal to:%n <2000-01-05T03:00:05.000Z>%n"));
       return;
     }
     fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/jodatime/api/datetime/DateTimeAssert_isNotIn_errors_Test.java
+++ b/src/test/java/org/assertj/jodatime/api/datetime/DateTimeAssert_isNotIn_errors_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.jodatime.api.datetime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.jodatime.api.Assertions.assertThat;
@@ -45,9 +46,9 @@ public class DateTimeAssert_isNotIn_errors_Test extends DateTimeAssertBaseTest {
       assertThat(new DateTime(2000, 1, 5, 3, 0, 5, UTC)).isNotIn(new DateTime(2000, 1, 5, 3, 0, 5, UTC).toString(),
           new DateTime(2012, 1, 1, 3, 3, 3, UTC).toString());
     } catch (AssertionError e) {
-      assertThat(e).hasMessage(
-          "\nExpecting:\n <2000-01-05T03:00:05.000Z>\nnot to be in:\n"
-              + " <[2000-01-05T03:00:05.000Z, 2012-01-01T03:03:03.000Z]>\n");
+      assertThat(e).hasMessage(format(
+          "%nExpecting:%n <2000-01-05T03:00:05.000Z>%nnot to be in:%n"
+              + " <[2000-01-05T03:00:05.000Z, 2012-01-01T03:03:03.000Z]>%n"));
       return;
     }
     fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/jodatime/api/localdatetime/LocalDateTimeAssert_isAfterOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/jodatime/api/localdatetime/LocalDateTimeAssert_isAfterOrEqualTo_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.jodatime.api.localdatetime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -48,7 +49,7 @@ public class LocalDateTimeAssert_isAfterOrEqualTo_Test extends LocalDateTimeAsse
     try {
       assertThat(new LocalDateTime(2000, 1, 5, 3, 0, 5)).isAfterOrEqualTo(new LocalDateTime(2012, 1, 1, 3, 3, 3));
     } catch (AssertionError e) {
-      assertThat(e).hasMessage("\nExpecting:\n  <2000-01-05T03:00:05.000>\nto be after or equals to:\n  <2012-01-01T03:03:03.000>\n");
+      assertThat(e).hasMessage(format("%nExpecting:%n  <2000-01-05T03:00:05.000>%nto be after or equals to:%n  <2012-01-01T03:03:03.000>%n"));
       return;
     }
     fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/jodatime/api/localdatetime/LocalDateTimeAssert_isAfter_Test.java
+++ b/src/test/java/org/assertj/jodatime/api/localdatetime/LocalDateTimeAssert_isAfter_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.jodatime.api.localdatetime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -49,7 +50,7 @@ public class LocalDateTimeAssert_isAfter_Test extends LocalDateTimeAssertBaseTes
     try {
       assertThat(new LocalDateTime(2000, 1, 5, 3, 0, 5)).isAfter(new LocalDateTime(2012, 1, 1, 3, 3, 3));
     } catch (AssertionError e) {
-      assertThat(e).hasMessage("\nExpecting:\n  <2000-01-05T03:00:05.000>\nto be strictly after:\n  <2012-01-01T03:03:03.000>\n");
+      assertThat(e).hasMessage(format("%nExpecting:%n  <2000-01-05T03:00:05.000>%nto be strictly after:%n  <2012-01-01T03:03:03.000>%n"));
       return;
     }
     fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/jodatime/api/localdatetime/LocalDateTimeAssert_isBeforeOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/jodatime/api/localdatetime/LocalDateTimeAssert_isBeforeOrEqualTo_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.jodatime.api.localdatetime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -48,7 +49,7 @@ public class LocalDateTimeAssert_isBeforeOrEqualTo_Test extends LocalDateTimeAss
     try {
       assertThat(new LocalDateTime(2000, 1, 5, 3, 0, 5)).isBeforeOrEqualTo(new LocalDateTime(1998, 1, 1, 3, 3, 3));
     } catch (AssertionError e) {
-      assertThat(e).hasMessage("\nExpecting:\n  <2000-01-05T03:00:05.000>\nto be before or equals to:\n  <1998-01-01T03:03:03.000>\n");
+      assertThat(e).hasMessage(format("%nExpecting:%n  <2000-01-05T03:00:05.000>%nto be before or equals to:%n  <1998-01-01T03:03:03.000>%n"));
       return;
     }
     fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/jodatime/api/localdatetime/LocalDateTimeAssert_isBefore_Test.java
+++ b/src/test/java/org/assertj/jodatime/api/localdatetime/LocalDateTimeAssert_isBefore_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.jodatime.api.localdatetime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -47,7 +48,7 @@ public class LocalDateTimeAssert_isBefore_Test extends LocalDateTimeAssertBaseTe
     try {
       assertThat(new LocalDateTime(2000, 1, 5, 3, 0, 5)).isBefore(new LocalDateTime(1998, 1, 1, 3, 3, 3));
     } catch (AssertionError e) {
-      assertThat(e).hasMessage("\nExpecting:\n  <2000-01-05T03:00:05.000>\nto be strictly before:\n  <1998-01-01T03:03:03.000>\n");
+      assertThat(e).hasMessage(format("%nExpecting:%n  <2000-01-05T03:00:05.000>%nto be strictly before:%n  <1998-01-01T03:03:03.000>%n"));
       return;
     }
     fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/jodatime/api/localdatetime/LocalDateTimeAssert_isEqualToIgnoringHours_Test.java
+++ b/src/test/java/org/assertj/jodatime/api/localdatetime/LocalDateTimeAssert_isEqualToIgnoringHours_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.jodatime.api.localdatetime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.jodatime.api.Assertions.assertThat;
@@ -36,8 +37,8 @@ public class LocalDateTimeAssert_isEqualToIgnoringHours_Test extends JodaTimeBas
       assertThat(refLocalDateTime).isEqualToIgnoringHours(refLocalDateTime.minusHours(1));
     } catch (AssertionError e) {
       assertThat(e.getMessage())
-          .isEqualTo(
-              "\nExpecting:\n  <2000-01-02T00:00:00.000>\nto have same year, month and day as:\n  <2000-01-01T23:00:00.000>\nbut had not.");
+          .isEqualTo(format(
+              "%nExpecting:%n  <2000-01-02T00:00:00.000>%nto have same year, month and day as:%n  <2000-01-01T23:00:00.000>%nbut had not."));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();
@@ -49,8 +50,8 @@ public class LocalDateTimeAssert_isEqualToIgnoringHours_Test extends JodaTimeBas
       assertThat(refLocalDateTime).isEqualToIgnoringHours(refLocalDateTime.minusMillis(1));
     } catch (AssertionError e) {
       assertThat(e.getMessage())
-          .isEqualTo(
-              "\nExpecting:\n  <2000-01-02T00:00:00.000>\nto have same year, month and day as:\n  <2000-01-01T23:59:59.999>\nbut had not.");
+          .isEqualTo(format(
+              "%nExpecting:%n  <2000-01-02T00:00:00.000>%nto have same year, month and day as:%n  <2000-01-01T23:59:59.999>%nbut had not."));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();

--- a/src/test/java/org/assertj/jodatime/api/localdatetime/LocalDateTimeAssert_isEqualToIgnoringMilliseconds_Test.java
+++ b/src/test/java/org/assertj/jodatime/api/localdatetime/LocalDateTimeAssert_isEqualToIgnoringMilliseconds_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.jodatime.api.localdatetime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.jodatime.api.Assertions.assertThat;
@@ -38,8 +39,8 @@ public class LocalDateTimeAssert_isEqualToIgnoringMilliseconds_Test extends Joda
       assertThat(refLocalDateTime).isEqualToIgnoringMillis(refLocalDateTime.plusSeconds(1));
     } catch (AssertionError e) {
       assertThat(e.getMessage())
-          .isEqualTo(
-              "\nExpecting:\n  <2000-01-01T00:00:01.000>\nto have same year, month, day, hour, minute and second as:\n  <2000-01-01T00:00:02.000>\nbut had not.");
+          .isEqualTo(format(
+              "%nExpecting:%n  <2000-01-01T00:00:01.000>%nto have same year, month, day, hour, minute and second as:%n  <2000-01-01T00:00:02.000>%nbut had not."));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();
@@ -51,8 +52,8 @@ public class LocalDateTimeAssert_isEqualToIgnoringMilliseconds_Test extends Joda
       assertThat(refLocalDateTime).isEqualToIgnoringMillis(refLocalDateTime.minusMillis(1));
     } catch (AssertionError e) {
       assertThat(e.getMessage())
-          .isEqualTo(
-              "\nExpecting:\n  <2000-01-01T00:00:01.000>\nto have same year, month, day, hour, minute and second as:\n  <2000-01-01T00:00:00.999>\nbut had not.");
+          .isEqualTo(format(
+              "%nExpecting:%n  <2000-01-01T00:00:01.000>%nto have same year, month, day, hour, minute and second as:%n  <2000-01-01T00:00:00.999>%nbut had not."));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();

--- a/src/test/java/org/assertj/jodatime/api/localdatetime/LocalDateTimeAssert_isEqualToIgnoringMinutes_Test.java
+++ b/src/test/java/org/assertj/jodatime/api/localdatetime/LocalDateTimeAssert_isEqualToIgnoringMinutes_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.jodatime.api.localdatetime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.jodatime.api.Assertions.assertThat;
@@ -37,8 +38,8 @@ public class LocalDateTimeAssert_isEqualToIgnoringMinutes_Test extends JodaTimeB
       assertThat(refLocalDateTime).isEqualToIgnoringMinutes(refLocalDateTime.minusMinutes(1));
     } catch (AssertionError e) {
       assertThat(e.getMessage())
-          .isEqualTo(
-              "\nExpecting:\n  <2000-01-01T23:00:00.000>\nto have same year, month, day and hour as:\n  <2000-01-01T22:59:00.000>\nbut had not.");
+          .isEqualTo(format(
+              "%nExpecting:%n  <2000-01-01T23:00:00.000>%nto have same year, month, day and hour as:%n  <2000-01-01T22:59:00.000>%nbut had not."));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();
@@ -50,8 +51,8 @@ public class LocalDateTimeAssert_isEqualToIgnoringMinutes_Test extends JodaTimeB
       assertThat(refLocalDateTime).isEqualToIgnoringMinutes(refLocalDateTime.minusMillis(1));
     } catch (AssertionError e) {
       assertThat(e.getMessage())
-          .isEqualTo(
-              "\nExpecting:\n  <2000-01-01T23:00:00.000>\nto have same year, month, day and hour as:\n  <2000-01-01T22:59:59.999>\nbut had not.");
+          .isEqualTo(format(
+              "%nExpecting:%n  <2000-01-01T23:00:00.000>%nto have same year, month, day and hour as:%n  <2000-01-01T22:59:59.999>%nbut had not."));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();

--- a/src/test/java/org/assertj/jodatime/api/localdatetime/LocalDateTimeAssert_isEqualToIgnoringSeconds_Test.java
+++ b/src/test/java/org/assertj/jodatime/api/localdatetime/LocalDateTimeAssert_isEqualToIgnoringSeconds_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.jodatime.api.localdatetime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.jodatime.api.Assertions.assertThat;
@@ -37,8 +38,8 @@ public class LocalDateTimeAssert_isEqualToIgnoringSeconds_Test extends JodaTimeB
       assertThat(refLocalDateTime).isEqualToIgnoringSeconds(refLocalDateTime.plusMinutes(1));
     } catch (AssertionError e) {
       assertThat(e.getMessage())
-          .isEqualTo(
-              "\nExpecting:\n  <2000-01-01T23:51:00.000>\nto have same year, month, day, hour and minute as:\n  <2000-01-01T23:52:00.000>\nbut had not.");
+          .isEqualTo(format(
+              "%nExpecting:%n  <2000-01-01T23:51:00.000>%nto have same year, month, day, hour and minute as:%n  <2000-01-01T23:52:00.000>%nbut had not."));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();
@@ -50,8 +51,8 @@ public class LocalDateTimeAssert_isEqualToIgnoringSeconds_Test extends JodaTimeB
       assertThat(refLocalDateTime).isEqualToIgnoringSeconds(refLocalDateTime.minusMillis(1));
     } catch (AssertionError e) {
       assertThat(e.getMessage())
-          .isEqualTo(
-              "\nExpecting:\n  <2000-01-01T23:51:00.000>\nto have same year, month, day, hour and minute as:\n  <2000-01-01T23:50:59.999>\nbut had not.");
+          .isEqualTo(format(
+              "%nExpecting:%n  <2000-01-01T23:51:00.000>%nto have same year, month, day, hour and minute as:%n  <2000-01-01T23:50:59.999>%nbut had not."));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();

--- a/src/test/java/org/assertj/jodatime/api/localdatetime/LocalDateTimeAssert_isIn_Test.java
+++ b/src/test/java/org/assertj/jodatime/api/localdatetime/LocalDateTimeAssert_isIn_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.jodatime.api.localdatetime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.jodatime.api.Assertions.assertThat;
@@ -43,7 +44,7 @@ public class LocalDateTimeAssert_isIn_Test extends LocalDateTimeAssertBaseTest {
     try {
       assertThat(new LocalDateTime(2000, 1, 5, 3, 0, 5)).isIn(new LocalDateTime(2012, 1, 1, 3, 3, 3).toString());
     } catch (AssertionError e) {
-      assertThat(e).hasMessage("\nExpecting:\n <2000-01-05T03:00:05.000>\nto be in:\n <[2012-01-01T03:03:03.000]>\n");
+      assertThat(e).hasMessage(format("%nExpecting:%n <2000-01-05T03:00:05.000>%nto be in:%n <[2012-01-01T03:03:03.000]>%n"));
       return;
     }
     fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/jodatime/api/localdatetime/LocalDateTimeAssert_isNotEqualTo_Test.java
+++ b/src/test/java/org/assertj/jodatime/api/localdatetime/LocalDateTimeAssert_isNotEqualTo_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.jodatime.api.localdatetime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.jodatime.api.Assertions.assertThat;
@@ -44,7 +45,7 @@ public class LocalDateTimeAssert_isNotEqualTo_Test extends LocalDateTimeAssertBa
       assertThat(new LocalDateTime(2000, 1, 5, 3, 0, 5))
           .isNotEqualTo(new LocalDateTime(2000, 1, 5, 3, 0, 5).toString());
     } catch (AssertionError e) {
-      assertThat(e).hasMessage("\nExpecting:\n <2000-01-05T03:00:05.000>\nnot to be equal to:\n <2000-01-05T03:00:05.000>\n");
+      assertThat(e).hasMessage(format("%nExpecting:%n <2000-01-05T03:00:05.000>%nnot to be equal to:%n <2000-01-05T03:00:05.000>%n"));
       return;
     }
     fail("Should have thrown AssertionError");

--- a/src/test/java/org/assertj/jodatime/api/localdatetime/LocalDateTimeAssert_isNotIn_Test.java
+++ b/src/test/java/org/assertj/jodatime/api/localdatetime/LocalDateTimeAssert_isNotIn_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.jodatime.api.localdatetime;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.jodatime.api.Assertions.assertThat;
@@ -45,8 +46,8 @@ public class LocalDateTimeAssert_isNotIn_Test extends LocalDateTimeAssertBaseTes
           new LocalDateTime(2012, 1, 1, 3, 3, 3).toString());
     } catch (AssertionError e) {
       assertThat(e)
-          .hasMessage(
-              "\nExpecting:\n <2000-01-05T03:00:05.000>\nnot to be in:\n <[2000-01-05T03:00:05.000, 2012-01-01T03:03:03.000]>\n");
+          .hasMessage(format(
+              "%nExpecting:%n <2000-01-05T03:00:05.000>%nnot to be in:%n <[2000-01-05T03:00:05.000, 2012-01-01T03:03:03.000]>%n"));
       return;
     }
     fail("Should have thrown AssertionError");


### PR DESCRIPTION
…of "\n" (fixes #9)

Update assertj-core dependency to 2.1-2.X to make this work